### PR TITLE
Fix for PHP 8.1 deprecation messages

### DIFF
--- a/src/Traits/ImmutableArray.php
+++ b/src/Traits/ImmutableArray.php
@@ -52,7 +52,7 @@ trait ImmutableArray
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return $this->toArray()[$offset] ?? null;
     }

--- a/src/Traits/SerializableContainer.php
+++ b/src/Traits/SerializableContainer.php
@@ -29,6 +29,28 @@ trait SerializableContainer
     }
 
     /**
+     * Returns array containing all the necessary state of the object.
+     *
+     * @return array
+     */
+    public function __serialize(): array
+    {
+        return [
+            'container' => $this->toContainer()
+        ];
+    }
+
+    /**
+     * Restores the object state from the given data array.
+     *
+     * @param array $serialized
+     */
+    public function __unserialize(array $serialized)
+    {
+        $this->container = $serialized['container'];
+    }
+
+    /**
      * Serializes the object to a value that can be serialized by json_encode().
      *
      * @return array


### PR DESCRIPTION
Specified return type of mixed on ImmutableArray::offsetGet() function to silence PHP deprecation message. Added __serialize() and __unserialize() functions to SerializableContainer class to silence PHP Serializable interface deprecation messages.

The deprecation messages:
```
PHP Deprecated:  
Denpa\Bitcoin\Responses\BitcoindResponse implements the Serializable interface, which is deprecated.
Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) 
in /var/www/html/vendor/denpa/php-bitcoinrpc/src/Responses/BitcoindResponse.php on line 11
PHP Deprecated:  
Denpa\Bitcoin\Responses\LaravelResponse implements the Serializable interface, which is deprecated.
Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) 
in /var/www/html/vendor/denpa/laravel-bitcoinrpc/src/Responses/LaravelResponse.php on line 9

PHP Deprecated:  
Return type of Denpa\Bitcoin\Config::offsetGet($offset) should either be compatible with 
ArrayAccess::offsetGet(mixed $offset): mixed, or the 
#[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice 
in /var/www/html/vendor/denpa/php-bitcoinrpc/src/Traits/ImmutableArray.php on line 55
PHP Deprecated:  
Return type of Denpa\Bitcoin\Responses\BitcoindResponse::offsetGet($offset) 
should either be compatible with
ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be 
used to temporarily suppress the notice in 
/var/www/html/vendor/denpa/php-bitcoinrpc/src/Traits/ImmutableArray.php on line 55
```